### PR TITLE
Support default config names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,7 @@ inputs:
       default: ${{ github.token }}
   vite-config-path:
       required: false
-      description: 'The path to the vite config file. Uses "vite.config.js" by default.'
-      default: vite.config.js
+      description: 'The path to the vite config file. Looks for paths on the form "vite[st].config.{t|mt|ct|j|mj|cj}s" by default.'
   json-summary-path:
       required: false
       description: 'The path to the json summary file. Uses "coverage/coverage-summary.json" by default.'

--- a/src/getViteConfigPath.test.ts
+++ b/src/getViteConfigPath.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import path from "path";
+import * as core from "@actions/core"
+import { getViteConfigPath } from "./getViteConfigPath";
+
+describe("getViteConfigPath", () => {
+  const mockWorkingDirectory = path.resolve(
+    __dirname,
+    "..",
+    "test",
+    "mockConfig"
+  );
+
+  it("resolves with a full path if a file at the provided path exists", async (): Promise<void> => {
+    await expect(
+      getViteConfigPath(mockWorkingDirectory, "vitest.config.all.js")
+    ).resolves.toMatch('test/mockConfig/vitest.config.all.js');
+  });
+
+  it("resolves with a full path if no path is provided but a file with a default name exists", async (): Promise<void> => {
+    await expect(getViteConfigPath(mockWorkingDirectory, "")).resolves.toMatch(
+      'test/mockConfig/vitest.config.js'
+    );
+  });
+
+  it("rejects if config file can not be found", async (): Promise<void> => {
+    vi.spyOn(core, 'setFailed').mockImplementationOnce(() => { })
+    await expect(
+      getViteConfigPath(mockWorkingDirectory, "doesNotExist")
+    ).rejects.toThrow(/unable to find config file/i);
+  });
+});

--- a/src/getViteConfigPath.ts
+++ b/src/getViteConfigPath.ts
@@ -30,9 +30,9 @@ const getViteConfigPath = async (workingDirectory: string, input: string) => {
       return await Promise.any(
         defaultPaths.map((filePath) => testFilePath(workingDirectory, filePath))
       );
-    } else {
-      return await testFilePath(workingDirectory, input);
-    }
+    } 
+    
+    return await testFilePath(workingDirectory, input);
   } catch (error) {
     core.setFailed(stripIndent`
           Failed to read vite config file"${workingDirectory}/${input}" or any of the default locations.

--- a/src/getViteConfigPath.ts
+++ b/src/getViteConfigPath.ts
@@ -1,0 +1,50 @@
+import * as core from "@actions/core";
+import path from "node:path";
+import { constants, promises as fs } from "fs";
+import { stripIndent } from "common-tags";
+
+const testFilePath = async (workingDirectory: string, filePath: string) => {
+  const resolvedPath = path.resolve(workingDirectory, filePath);
+  await fs.access(resolvedPath, constants.R_OK);
+  return resolvedPath;
+};
+
+const defaultPaths = [
+  "vitest.config.ts",
+  "vitest.config.mts",
+  "vitest.config.cts",
+  "vitest.config.js",
+  "vitest.config.mjs",
+  "vitest.config.cjs",
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.cts",
+  "vite.config.js",
+  "vite.config.mjs",
+  "vite.config.cjs",
+];
+
+const getViteConfigPath = async (workingDirectory: string, input: string) => {
+  try {
+    if (input === "") {
+      return await Promise.any(
+        defaultPaths.map((filePath) => testFilePath(workingDirectory, filePath))
+      );
+    } else {
+      return await testFilePath(workingDirectory, input);
+    }
+  } catch (error) {
+    core.setFailed(stripIndent`
+          Failed to read vite config file"${workingDirectory}/${input}" or any of the default locations.
+          Make sure you provide the vite-config-path option if you're using a non-default location or name of your config file.
+      `);
+    throw new Error(
+      `Unable to find config file "${workingDirectory}/${input}".`,
+      {
+        cause: error,
+      }
+    );
+  }
+};
+
+export { getViteConfigPath };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import * as core from '@actions/core';
 import {RequestError} from '@octokit/request-error'
 import { parseCoverageThresholds } from './parseCoverageThresholds.js';
 import { generateFileCoverageHtml } from './generateFileCoverageHtml.js';
+import { getViteConfigPath } from './getViteConfigPath.js';
 
 const run = async () => {
   // Working directory can be used to modify all default/provided paths (for monorepos, etc)
@@ -13,7 +14,7 @@ const run = async () => {
 
   const jsonSummaryPath = path.resolve(workingDirectory, core.getInput('json-summary-path'));
   const jsonFinalPath = path.resolve(workingDirectory, core.getInput('json-final-path'));
-  const viteConfigPath = path.resolve(workingDirectory, core.getInput('vite-config-path'));
+  const viteConfigPath = await getViteConfigPath(workingDirectory, core.getInput("vite-config-path"));
 
   const jsonSummary = await parseVitestJsonSummary(jsonSummaryPath);
   const jsonFinal = await parseVitestJsonFinal(jsonFinalPath);


### PR DESCRIPTION
This PR adds a new function `getViteConfigPath` which attempts to access a file at the provided path and in cases where no path is provided it will run through a list of default paths / filenames and see if it can find on of those instead.
This effectively replaces the default value for the `vite-config-path` option in `action.yml` so this default has been removed and the description of the option updated.

Fixes #167