### PR TITLE
Fix vite-config-path default cell in Options table

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This action requires permissions set to `pull-request: write` in order for it to
 | ------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------- |
 | `json-summary-path` | The path to the json summary file.                                                              | `./coverage/coverage-summary.json` |
 | `json-final-path`   | The path to the json final file.                                                                | `./coverage/coverage-final.json`   |
-| `vite-config-path`  | The path to the vite config file. Will check the same paths as vite and vitest                  | Checks pattern `vite[st].config.{t|mt|ct|j|mj|cj}s`               |
+| `vite-config-path`  | The path to the vite config file. Will check the same paths as vite and vitest                  | Checks pattern `vite[st].config.{t\|mt\|ct\|j\|mj\|cj}s`               |
 | `github-token`      | A GitHub access token with permissions to write to issues (defaults to `secrets.GITHUB_TOKEN`). | `${{ github.token }}`              |
 | `working-directory` | Run action within a custom directory (for monorepos).                                           | `./`                               |
 | `name` | Give the report a name. This is useful if you want multiple reports for different test suites within the same PR. Needs to be unique. | '' |


### PR DESCRIPTION
The code snippet in the "Default" column of the "vite-config-path" row was being cut off because the pipe (|) characters were not being escaped.