### PR TITLE
ci: Splits test execution and coverage reporting

### DIFF
--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -1,0 +1,19 @@
+name: Report Coverage
+
+on:
+  workflow_run:
+    workflows: ["Build and Test"]
+    types:
+      - completed
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          # Name of the artifact to download.
+          # Optional. If unspecified, all artifacts for the run are downloaded.
+          name: coverage
+          run-id: ${{ github.event.workflow_run.id }}
+      - run: ls -l

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,20 @@ jobs:
         # Remove node_modules to see if this action runs entirely compiled
       - name: "Remove Node Modules"
         run: rm -rf node_modules
-      - name: "Test Working Directory Option"
-        uses: ./
+      - name: "Upload Coverage"
+        uses: actions/upload-artifact@v4
         with:
-          working-directory: "./test/mockReports"
-          name: "Mock Reports"
-      - name: "Test Default Action"
-        # run step also on failure of the previous step
-        if: always()
-        uses: ./
-        with:
-          file-coverage-mode: "all"
-          name: "Root"
+          name: coverage
+          path: coverage
+      # - name: "Test Working Directory Option"
+      #   uses: ./
+      #   with:
+      #     working-directory: "./test/mockReports"
+      #     name: "Mock Reports"
+      # - name: "Test Default Action"
+      #   # run step also on failure of the previous step
+      #   if: always()
+      #   uses: ./
+      #   with:
+      #     file-coverage-mode: "all"
+      #     name: "Root"


### PR DESCRIPTION
This pull request primarily focuses on the reconfiguration of the GitHub Actions workflows to improve the coverage reporting process. The most significant changes involve the creation of a new workflow, `Report Coverage`, and the modification of the `test.yml` workflow to upload coverage reports as artifacts.

Here are the key changes:

New Workflow Creation:

* <a href="diffhunk://#diff-76ed3ec8a242094a6b82775762ae2a1d69f27eaa3070f3201ad0fea58b70597bR1-R19">`.github/workflows/report-coverage.yml`</a>: A new workflow named `Report Coverage` has been introduced. This workflow triggers upon the completion of the `Build and Test` workflow and is responsible for downloading the coverage reports generated during testing.

Workflow Modification:

* <a href="diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L25-R41">`.github/workflows/test.yml`</a>: The `Test Working Directory Option` and `Test Default Action` steps have been commented out. Instead, a new step named `Upload Coverage` has been added. This step uses the `upload-artifact` action to upload the coverage reports generated during testing, which can then be downloaded by the `Report Coverage` workflow.