### PR TITLE
deps: Upgrades action and all references of node to newest version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Install Node"
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "20.x"
       - name: "Install Deps"
         run: npm install
       - name: "Build"

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: 'Install Node'
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
-        node-version: '16.x'
+        node-version: '20.x'
     - name: 'Install Deps'
       run: npm install
     - name: 'Test'
@@ -125,10 +125,12 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   test: {
     coverage: {
-      lines: 60,
-      branches: 60,
-      functions: 60,
-      statements: 60
+      thresholds: {
+        lines: 60,
+        branches: 60,
+        functions: 60,
+        statements: 60
+      }
     }
   }
 });
@@ -209,7 +211,7 @@ It will then automatically locate the appropriate pull request to comment on.
           - name: "Install Node"
             uses: actions/setup-node@v4
             with:
-              node-version: "18.x"
+              node-version: "20.x"
           - name: "Install Deps"
             run: npm install
           - name: "Test"

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
       description: 'The name of the coverage report. Can be used to execute this action multiple times. '
       default: ''
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'check-circle'


### PR DESCRIPTION
This pull request updates this action to use Node Version 20. This should not be a breaking change in any shape or form.

It also updates all actions to use the newest versions for checkout and setup-node, as well as all documentation to use these new versions.