### PR TITLE
Fixes "Coverage Trend Indicator" workflow for PRs with slash ('/') in name

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch:
-          - ${{ github.head_ref }}
-          - "main"
+        include:
+          - branch: main
+            artifact: main
+          - branch: ${{ github.head_ref }}
+            artifact: pull-request
 
     permissions:
       # Required to checkout the code
@@ -193,7 +195,7 @@ jobs:
       - name: "Upload Coverage"
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.branch }}
+          name: coverage-${{ matrix.artifact }}
           path: coverage
 
   report-coverage:
@@ -203,7 +205,7 @@ jobs:
       - name: "Download Coverage Artifacts"
         uses: actions/download-artifact@v4
         with:
-          name: coverage-${{ github.head_ref }}
+          name: coverage-pull-request
           path: coverage
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This PR fixes the "Coverage Trend Indicator" workflow example so that it will run successfully in with dependabot PR's and (more generally) any PR with a slash (/) in it's name.

Background: Artifacts (`actions/upload-artifact`) cannot have forward slashes ('/') in the name.  As such, dependabot PRs will fail, as could other git branch naming systems like gitflow and others (that use slashes in the branch names).

The fix involves explicitly naming the artifacts by using [`strategy.matrix.include`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#expanding-or-adding-matrix-configurations) to specify the `branch` name to checkout and `artifact` name to upload.