### PR TITLE
fix: color status icon by vitest threshold pass/fail when threshold-icons is unset

### DIFF
--- a/src/inputs/options.ts
+++ b/src/inputs/options.ts
@@ -1,6 +1,5 @@
 import * as path from "node:path";
 import * as core from "@actions/core";
-import { defaultThresholdIcons } from "../icons";
 import type { Octokit } from "../octokit";
 import type { Thresholds } from "../types/Threshold";
 import type { ThresholdIcons } from "../types/ThresholdIcons";
@@ -23,7 +22,7 @@ type Options = {
 	jsonSummaryComparePath: string | null;
 	name: string;
 	thresholds: Thresholds;
-	thresholdIcons: ThresholdIcons;
+	thresholdIcons: ThresholdIcons | undefined;
 	workingDirectory: string;
 	prNumber: number | undefined;
 	commitSHA: string;
@@ -115,22 +114,20 @@ async function readOptions(octokit: Octokit): Promise<Options> {
 		core.getInput("threshold-icons"),
 	);
 
-	// Normalize threshold icons: always have a valid ThresholdIcons object
-	// - If valid icons provided, use them
-	// - If both coverage thresholds AND icons provided, warn about potential mismatch
-	// - If no valid icons, use default (blue circles)
-	let thresholdIcons: ThresholdIcons;
-	if (parsedThresholdIcons) {
-		thresholdIcons = parsedThresholdIcons;
-		if (hasThresholds(thresholds)) {
-			core.warning(
-				"Both coverage thresholds and threshold-icons are defined. " +
-					"The threshold-icons will be used for status display, but they may not reflect " +
-					"the actual pass/fail status from the coverage thresholds.",
-			);
-		}
-	} else {
-		thresholdIcons = defaultThresholdIcons;
+	// Normalize threshold icons:
+	// - If the user explicitly provided valid threshold-icons, use them (and
+	//   warn if vitest coverage thresholds are also defined, since the two
+	//   may disagree on pass/fail boundaries).
+	// - Otherwise leave it undefined, so the report falls back to coloring
+	//   each row by pass/fail against that category's vitest threshold (if
+	//   any is defined), rather than forcing every row to blue.
+	const thresholdIcons = parsedThresholdIcons;
+	if (thresholdIcons && hasThresholds(thresholds)) {
+		core.warning(
+			"Both coverage thresholds and threshold-icons are defined. " +
+				"The threshold-icons will be used for status display, but they may not reflect " +
+				"the actual pass/fail status from the coverage thresholds.",
+		);
 	}
 
 	const commitSHA = getCommitSHA();

--- a/src/inputs/options.ts
+++ b/src/inputs/options.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import * as core from "@actions/core";
 import type { Octokit } from "../octokit";
 import type { Thresholds } from "../types/Threshold";
-import type { ThresholdIcons } from "../types/ThresholdIcons";
+import type { ThresholdIconsByCategory } from "../types/ThresholdIcons";
 import { type FileCoverageMode, getCoverageModeFrom } from "./FileCoverageMode";
 import { type CommentOn, getCommentOn } from "./getCommentOn";
 import { getCommitSHA } from "./getCommitSHA";
@@ -10,6 +10,7 @@ import { getPullRequestNumber } from "./getPullRequestNumber";
 import { getViteConfigPath } from "./getViteConfigPath";
 import { parseCoverageThresholds } from "./parseCoverageThresholds";
 import { parseThresholdIcons } from "./parseThresholdIcons";
+import { resolveThresholdIcons } from "./resolveThresholdIcons";
 import { getSortByFrom, type SortBy } from "./sortBy";
 
 type Options = {
@@ -22,7 +23,7 @@ type Options = {
 	jsonSummaryComparePath: string | null;
 	name: string;
 	thresholds: Thresholds;
-	thresholdIcons: ThresholdIcons | undefined;
+	thresholdIcons: ThresholdIconsByCategory;
 	workingDirectory: string;
 	prNumber: number | undefined;
 	commitSHA: string;
@@ -114,21 +115,18 @@ async function readOptions(octokit: Octokit): Promise<Options> {
 		core.getInput("threshold-icons"),
 	);
 
-	// Normalize threshold icons:
-	// - If the user explicitly provided valid threshold-icons, use them (and
-	//   warn if vitest coverage thresholds are also defined, since the two
-	//   may disagree on pass/fail boundaries).
-	// - Otherwise leave it undefined, so the report falls back to coloring
-	//   each row by pass/fail against that category's vitest threshold (if
-	//   any is defined), rather than forcing every row to blue.
-	const thresholdIcons = parsedThresholdIcons;
-	if (thresholdIcons && hasThresholds(thresholds)) {
+	if (parsedThresholdIcons && hasThresholds(thresholds)) {
 		core.warning(
 			"Both coverage thresholds and threshold-icons are defined. " +
 				"The threshold-icons will be used for status display, but they may not reflect " +
 				"the actual pass/fail status from the coverage thresholds.",
 		);
 	}
+
+	const thresholdIcons = resolveThresholdIcons(
+		thresholds,
+		parsedThresholdIcons,
+	);
 
 	const commitSHA = getCommitSHA();
 

--- a/src/inputs/resolveThresholdIcons.test.ts
+++ b/src/inputs/resolveThresholdIcons.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { defaultThresholdIcons, icons } from "../icons";
+import type { Thresholds } from "../types/Threshold";
+import type { ThresholdIcons } from "../types/ThresholdIcons";
+import { resolveThresholdIcons } from "./resolveThresholdIcons";
+
+describe("resolveThresholdIcons()", () => {
+	it("resolves every category to the blue default when nothing is configured", () => {
+		const resolved = resolveThresholdIcons({}, undefined);
+
+		expect(resolved.lines).toEqual(defaultThresholdIcons);
+		expect(resolved.statements).toEqual(defaultThresholdIcons);
+		expect(resolved.functions).toEqual(defaultThresholdIcons);
+		expect(resolved.branches).toEqual(defaultThresholdIcons);
+	});
+
+	it("resolves a category with a vitest threshold to red-below/green-at-or-above that threshold", () => {
+		const thresholds: Thresholds = { lines: 80 };
+
+		const resolved = resolveThresholdIcons(thresholds, undefined);
+
+		expect(resolved.lines).toEqual({ 0: icons.red, 80: icons.green });
+	});
+
+	it("resolves each category independently based on its own vitest threshold", () => {
+		const thresholds: Thresholds = {
+			lines: 80,
+			statements: 70,
+		};
+
+		const resolved = resolveThresholdIcons(thresholds, undefined);
+
+		expect(resolved.lines).toEqual({ 0: icons.red, 80: icons.green });
+		expect(resolved.statements).toEqual({ 0: icons.red, 70: icons.green });
+		expect(resolved.functions).toEqual(defaultThresholdIcons);
+		expect(resolved.branches).toEqual(defaultThresholdIcons);
+	});
+
+	it("uses the explicit threshold-icons for every category when provided, ignoring vitest thresholds", () => {
+		const thresholds: Thresholds = { lines: 80, branches: 90 };
+		const explicitThresholdIcons: ThresholdIcons = {
+			0: "❌",
+			50: "⚠️",
+			90: "✅",
+		};
+
+		const resolved = resolveThresholdIcons(thresholds, explicitThresholdIcons);
+
+		expect(resolved.lines).toBe(explicitThresholdIcons);
+		expect(resolved.statements).toBe(explicitThresholdIcons);
+		expect(resolved.functions).toBe(explicitThresholdIcons);
+		expect(resolved.branches).toBe(explicitThresholdIcons);
+	});
+});

--- a/src/inputs/resolveThresholdIcons.ts
+++ b/src/inputs/resolveThresholdIcons.ts
@@ -1,0 +1,45 @@
+import { defaultThresholdIcons, icons } from "../icons";
+import type { Thresholds } from "../types/Threshold";
+import type {
+	ThresholdIcons,
+	ThresholdIconsByCategory,
+} from "../types/ThresholdIcons";
+
+function resolveCategoryIcons(
+	threshold: number | undefined,
+	explicitThresholdIcons: ThresholdIcons | undefined,
+): ThresholdIcons {
+	if (explicitThresholdIcons) {
+		return explicitThresholdIcons;
+	}
+
+	if (threshold !== undefined) {
+		return { 0: icons.red, [threshold]: icons.green };
+	}
+
+	return defaultThresholdIcons;
+}
+
+/**
+ * Explicit threshold-icons win; otherwise each category falls back to
+ * pass/fail against its own vitest threshold, or blue if neither is set.
+ */
+function resolveThresholdIcons(
+	thresholds: Thresholds,
+	explicitThresholdIcons: ThresholdIcons | undefined,
+): ThresholdIconsByCategory {
+	return {
+		lines: resolveCategoryIcons(thresholds.lines, explicitThresholdIcons),
+		statements: resolveCategoryIcons(
+			thresholds.statements,
+			explicitThresholdIcons,
+		),
+		functions: resolveCategoryIcons(
+			thresholds.functions,
+			explicitThresholdIcons,
+		),
+		branches: resolveCategoryIcons(thresholds.branches, explicitThresholdIcons),
+	};
+}
+
+export { resolveThresholdIcons };

--- a/src/report/generateSummaryTableHtml.test.ts
+++ b/src/report/generateSummaryTableHtml.test.ts
@@ -6,8 +6,23 @@ import {
 	createMockReportNumbers,
 } from "../types/JsonSummaryMockFactory";
 import type { Thresholds } from "../types/Threshold";
-import type { ThresholdIcons } from "../types/ThresholdIcons";
+import type {
+	ThresholdIcons,
+	ThresholdIconsByCategory,
+} from "../types/ThresholdIcons";
 import { generateSummaryTableHtml } from "./generateSummaryTableHtml";
+
+/** Applies the same ThresholdIcons map to every category, for tests that only inspect the "Lines" row. */
+function everyCategory(
+	thresholdIcons: ThresholdIcons,
+): ThresholdIconsByCategory {
+	return {
+		lines: thresholdIcons,
+		statements: thresholdIcons,
+		functions: thresholdIcons,
+		branches: thresholdIcons,
+	};
+}
 
 describe("generateSummaryTabelHtml()", () => {
 	it("generates the headline", () => {
@@ -81,7 +96,8 @@ describe("generateSummaryTabelHtml()", () => {
 		expect(getTableLine(1, summaryHtml)).toContain("8 / 10");
 	});
 
-	it("shows blue-circle when vitest threshold is defined but thresholdIcons is explicitly passed as the blue default.", async (): Promise<void> => {
+	it("renders the icon from the resolved per-category thresholdIcons, ignoring the raw threshold.", async (): Promise<void> => {
+		// precedence logic lives in resolveThresholdIcons.test.ts now
 		const thresholds: Thresholds = { lines: 80 };
 		const mockReport = createMockCoverageReport({
 			lines: createMockReportNumbers({
@@ -92,35 +108,10 @@ describe("generateSummaryTabelHtml()", () => {
 			mockReport,
 			thresholds,
 			undefined,
-			defaultThresholdIcons,
+			everyCategory(defaultThresholdIcons),
 		);
 
-		// Explicit thresholdIcons always wins over the vitest threshold pass/fail check.
 		expect(getTableLine(1, summaryHtml)).toContain(icons.blue);
-	});
-
-	it("shows green icon when coverage meets the vitest threshold and no thresholdIcons is provided.", async (): Promise<void> => {
-		const thresholds: Thresholds = { lines: 80 };
-		const mockReport = createMockCoverageReport({
-			lines: createMockReportNumbers({
-				pct: 81,
-			}),
-		});
-		const summaryHtml = generateSummaryTableHtml(mockReport, thresholds);
-
-		expect(getTableLine(1, summaryHtml)).toContain(icons.green);
-	});
-
-	it("shows red icon when coverage is below the vitest threshold and no thresholdIcons is provided.", async (): Promise<void> => {
-		const thresholds: Thresholds = { lines: 80 };
-		const mockReport = createMockCoverageReport({
-			lines: createMockReportNumbers({
-				pct: 79,
-			}),
-		});
-		const summaryHtml = generateSummaryTableHtml(mockReport, thresholds);
-
-		expect(getTableLine(1, summaryHtml)).toContain(icons.red);
 	});
 
 	it("if threshold is given, provides the threshold in the category column.", async (): Promise<void> => {
@@ -224,7 +215,7 @@ describe("generateSummaryTabelHtml()", () => {
 				mockReport,
 				undefined,
 				undefined,
-				thresholdIcons,
+				everyCategory(thresholdIcons),
 			);
 
 			expect(getTableLine(1, summaryHtml)).toContain("🟠");
@@ -246,7 +237,7 @@ describe("generateSummaryTabelHtml()", () => {
 				mockReport,
 				undefined,
 				undefined,
-				thresholdIcons,
+				everyCategory(thresholdIcons),
 			);
 
 			expect(getTableLine(1, summaryHtml)).toContain("🔴");
@@ -268,7 +259,7 @@ describe("generateSummaryTabelHtml()", () => {
 				mockReport,
 				undefined,
 				undefined,
-				thresholdIcons,
+				everyCategory(thresholdIcons),
 			);
 
 			expect(getTableLine(1, summaryHtml)).toContain("🟢");
@@ -289,13 +280,13 @@ describe("generateSummaryTabelHtml()", () => {
 				mockReport,
 				undefined,
 				undefined,
-				thresholdIcons,
+				everyCategory(thresholdIcons),
 			);
 
 			expect(getTableLine(1, summaryHtml)).toContain(icons.blue);
 		});
 
-		it("thresholdIcons takes precedence when both vitest threshold and thresholdIcons are provided", async (): Promise<void> => {
+		it("renders the given thresholdIcons even when a vitest threshold is also defined (target % still shown)", async (): Promise<void> => {
 			const thresholds: Thresholds = { lines: 80 };
 			const thresholdIcons: ThresholdIcons = {
 				0: "❌",
@@ -312,10 +303,10 @@ describe("generateSummaryTabelHtml()", () => {
 				mockReport,
 				thresholds,
 				undefined,
-				thresholdIcons,
+				everyCategory(thresholdIcons),
 			);
 
-			// thresholdIcons takes precedence - 85% matches the 50 threshold (⚠️)
+			// 85% matches the 50 threshold (⚠️)
 			expect(getTableLine(1, summaryHtml)).toContain("⚠️");
 			// But vitest threshold target should still be shown
 			expect(getTableLine(1, summaryHtml)).toContain("🎯 80%");
@@ -336,7 +327,7 @@ describe("generateSummaryTabelHtml()", () => {
 				mockReport,
 				undefined,
 				undefined,
-				thresholdIcons,
+				everyCategory(thresholdIcons),
 			);
 
 			expect(getTableLine(1, summaryHtml)).toContain("🟢");
@@ -360,7 +351,7 @@ describe("generateSummaryTabelHtml()", () => {
 				mockReport,
 				undefined,
 				mockCompareReport,
-				defaultThresholdIcons,
+				everyCategory(defaultThresholdIcons),
 				4, // custom decimal places
 			);
 

--- a/src/report/generateSummaryTableHtml.test.ts
+++ b/src/report/generateSummaryTableHtml.test.ts
@@ -81,7 +81,7 @@ describe("generateSummaryTabelHtml()", () => {
 		expect(getTableLine(1, summaryHtml)).toContain("8 / 10");
 	});
 
-	it("shows blue-circle when vitest threshold is defined but no custom thresholdIcons provided.", async (): Promise<void> => {
+	it("shows blue-circle when vitest threshold is defined but thresholdIcons is explicitly passed as the blue default.", async (): Promise<void> => {
 		const thresholds: Thresholds = { lines: 80 };
 		const mockReport = createMockCoverageReport({
 			lines: createMockReportNumbers({
@@ -95,8 +95,32 @@ describe("generateSummaryTabelHtml()", () => {
 			defaultThresholdIcons,
 		);
 
-		// With normalized behavior, default thresholdIcons (blue) is always used unless custom icons provided
+		// Explicit thresholdIcons always wins over the vitest threshold pass/fail check.
 		expect(getTableLine(1, summaryHtml)).toContain(icons.blue);
+	});
+
+	it("shows green icon when coverage meets the vitest threshold and no thresholdIcons is provided.", async (): Promise<void> => {
+		const thresholds: Thresholds = { lines: 80 };
+		const mockReport = createMockCoverageReport({
+			lines: createMockReportNumbers({
+				pct: 81,
+			}),
+		});
+		const summaryHtml = generateSummaryTableHtml(mockReport, thresholds);
+
+		expect(getTableLine(1, summaryHtml)).toContain(icons.green);
+	});
+
+	it("shows red icon when coverage is below the vitest threshold and no thresholdIcons is provided.", async (): Promise<void> => {
+		const thresholds: Thresholds = { lines: 80 };
+		const mockReport = createMockCoverageReport({
+			lines: createMockReportNumbers({
+				pct: 79,
+			}),
+		});
+		const summaryHtml = generateSummaryTableHtml(mockReport, thresholds);
+
+		expect(getTableLine(1, summaryHtml)).toContain(icons.red);
 	});
 
 	it("if threshold is given, provides the threshold in the category column.", async (): Promise<void> => {

--- a/src/report/generateSummaryTableHtml.ts
+++ b/src/report/generateSummaryTableHtml.ts
@@ -1,15 +1,25 @@
 import { oneLine } from "common-tags";
-import { icons } from "../icons";
+import { defaultThresholdIcons, icons } from "../icons";
 import type { CoverageReport, ReportNumbers } from "../types/JsonSummary";
 import type { Thresholds } from "../types/Threshold";
-import type { ThresholdIcons } from "../types/ThresholdIcons";
+import type {
+	ThresholdIcons,
+	ThresholdIconsByCategory,
+} from "../types/ThresholdIcons";
 import { getCompareString } from "./getCompareString";
+
+const allBlueThresholdIcons: ThresholdIconsByCategory = {
+	lines: defaultThresholdIcons,
+	statements: defaultThresholdIcons,
+	functions: defaultThresholdIcons,
+	branches: defaultThresholdIcons,
+};
 
 function generateSummaryTableHtml(
 	jsonReport: CoverageReport,
 	thresholds: Thresholds = {},
 	jsonCompareReport: CoverageReport | undefined = undefined,
-	thresholdIcons?: ThresholdIcons,
+	thresholdIcons: ThresholdIconsByCategory = allBlueThresholdIcons,
 	comparisonDecimalPlaces = 2,
 ): string {
 	return oneLine`
@@ -24,16 +34,16 @@ function generateSummaryTableHtml(
 			</thead>
 			<tbody>
 				<tr>
-					${generateTableRow({ reportNumbers: jsonReport.lines, category: "Lines", threshold: thresholds.lines, reportCompareNumbers: jsonCompareReport?.lines, thresholdIcons, comparisonDecimalPlaces })}
+					${generateTableRow({ reportNumbers: jsonReport.lines, category: "Lines", threshold: thresholds.lines, reportCompareNumbers: jsonCompareReport?.lines, thresholdIcons: thresholdIcons.lines, comparisonDecimalPlaces })}
 				</tr>
 				<tr>
-					${generateTableRow({ reportNumbers: jsonReport.statements, category: "Statements", threshold: thresholds.statements, reportCompareNumbers: jsonCompareReport?.statements, thresholdIcons, comparisonDecimalPlaces })}
+					${generateTableRow({ reportNumbers: jsonReport.statements, category: "Statements", threshold: thresholds.statements, reportCompareNumbers: jsonCompareReport?.statements, thresholdIcons: thresholdIcons.statements, comparisonDecimalPlaces })}
 				</tr>
 				<tr>
-					${generateTableRow({ reportNumbers: jsonReport.functions, category: "Functions", threshold: thresholds.functions, reportCompareNumbers: jsonCompareReport?.functions, thresholdIcons, comparisonDecimalPlaces })}
+					${generateTableRow({ reportNumbers: jsonReport.functions, category: "Functions", threshold: thresholds.functions, reportCompareNumbers: jsonCompareReport?.functions, thresholdIcons: thresholdIcons.functions, comparisonDecimalPlaces })}
 				</tr>
 				<tr>
-					${generateTableRow({ reportNumbers: jsonReport.branches, category: "Branches", threshold: thresholds.branches, reportCompareNumbers: jsonCompareReport?.branches, thresholdIcons, comparisonDecimalPlaces })}
+					${generateTableRow({ reportNumbers: jsonReport.branches, category: "Branches", threshold: thresholds.branches, reportCompareNumbers: jsonCompareReport?.branches, thresholdIcons: thresholdIcons.branches, comparisonDecimalPlaces })}
 				</tr>
 			</tbody>
 		</table>
@@ -62,29 +72,6 @@ function getStatusFromThresholdIcons(
 	return icons.blue;
 }
 
-/**
- * Determines the status icon for a single row.
- * - Explicit thresholdIcons (from the threshold-icons input) always wins.
- * - Otherwise, if a vitest coverage threshold is defined for this category,
- *   color by pass/fail against it.
- * - Otherwise, fall back to blue (no threshold configured at all).
- */
-function getStatus(
-	pct: number,
-	threshold: number | undefined,
-	thresholdIcons: ThresholdIcons | undefined,
-): string {
-	if (thresholdIcons) {
-		return getStatusFromThresholdIcons(pct, thresholdIcons);
-	}
-
-	if (threshold !== undefined) {
-		return pct >= threshold ? icons.green : icons.red;
-	}
-
-	return icons.blue;
-}
-
 function generateTableRow({
 	reportNumbers,
 	category,
@@ -97,7 +84,7 @@ function generateTableRow({
 	category: string;
 	threshold?: number;
 	reportCompareNumbers?: ReportNumbers;
-	thresholdIcons?: ThresholdIcons;
+	thresholdIcons: ThresholdIcons;
 	comparisonDecimalPlaces?: number;
 }): string {
 	let percent = `${reportNumbers.pct}%`;
@@ -107,7 +94,7 @@ function generateTableRow({
 		percent = `${percent} (${icons.target} ${threshold}%)`;
 	}
 
-	const status = getStatus(reportNumbers.pct, threshold, thresholdIcons);
+	const status = getStatusFromThresholdIcons(reportNumbers.pct, thresholdIcons);
 
 	if (reportCompareNumbers) {
 		const percentDiff = reportNumbers.pct - reportCompareNumbers.pct;

--- a/src/report/generateSummaryTableHtml.ts
+++ b/src/report/generateSummaryTableHtml.ts
@@ -1,5 +1,5 @@
 import { oneLine } from "common-tags";
-import { defaultThresholdIcons, icons } from "../icons";
+import { icons } from "../icons";
 import type { CoverageReport, ReportNumbers } from "../types/JsonSummary";
 import type { Thresholds } from "../types/Threshold";
 import type { ThresholdIcons } from "../types/ThresholdIcons";
@@ -9,7 +9,7 @@ function generateSummaryTableHtml(
 	jsonReport: CoverageReport,
 	thresholds: Thresholds = {},
 	jsonCompareReport: CoverageReport | undefined = undefined,
-	thresholdIcons: ThresholdIcons = defaultThresholdIcons,
+	thresholdIcons?: ThresholdIcons,
 	comparisonDecimalPlaces = 2,
 ): string {
 	return oneLine`
@@ -62,6 +62,29 @@ function getStatusFromThresholdIcons(
 	return icons.blue;
 }
 
+/**
+ * Determines the status icon for a single row.
+ * - Explicit thresholdIcons (from the threshold-icons input) always wins.
+ * - Otherwise, if a vitest coverage threshold is defined for this category,
+ *   color by pass/fail against it.
+ * - Otherwise, fall back to blue (no threshold configured at all).
+ */
+function getStatus(
+	pct: number,
+	threshold: number | undefined,
+	thresholdIcons: ThresholdIcons | undefined,
+): string {
+	if (thresholdIcons) {
+		return getStatusFromThresholdIcons(pct, thresholdIcons);
+	}
+
+	if (threshold !== undefined) {
+		return pct >= threshold ? icons.green : icons.red;
+	}
+
+	return icons.blue;
+}
+
 function generateTableRow({
 	reportNumbers,
 	category,
@@ -74,7 +97,7 @@ function generateTableRow({
 	category: string;
 	threshold?: number;
 	reportCompareNumbers?: ReportNumbers;
-	thresholdIcons: ThresholdIcons;
+	thresholdIcons?: ThresholdIcons;
 	comparisonDecimalPlaces?: number;
 }): string {
 	let percent = `${reportNumbers.pct}%`;
@@ -84,8 +107,7 @@ function generateTableRow({
 		percent = `${percent} (${icons.target} ${threshold}%)`;
 	}
 
-	// Always use thresholdIcons for status icon
-	const status = getStatusFromThresholdIcons(reportNumbers.pct, thresholdIcons);
+	const status = getStatus(reportNumbers.pct, threshold, thresholdIcons);
 
 	if (reportCompareNumbers) {
 		const percentDiff = reportNumbers.pct - reportCompareNumbers.pct;

--- a/src/types/ThresholdIcons.ts
+++ b/src/types/ThresholdIcons.ts
@@ -10,4 +10,12 @@
  */
 type ThresholdIcons = Record<number, string>;
 
-export type { ThresholdIcons };
+/** The resolved ThresholdIcons map to use for each coverage category. */
+type ThresholdIconsByCategory = {
+	lines: ThresholdIcons;
+	statements: ThresholdIcons;
+	functions: ThresholdIcons;
+	branches: ThresholdIcons;
+};
+
+export type { ThresholdIcons, ThresholdIconsByCategory };


### PR DESCRIPTION
Fixes #580

## Summary

#557 split `threshold-icons` from vitest `coverage.thresholds`: thresholds now only render the 🎯 target % annotation, while the status icon color comes solely from `threshold-icons`, which defaults to all-blue (`{0: '🔵'}`) when unset. As @davelosert noted in #580, this is a regression — it silently broke every setup that relies on `vitest.config.ts` thresholds alone for red/green status, and contradicts the README, which still documents that thresholds are used "to determine the status of the generated report."

This restores that as the default: when `threshold-icons` isn't explicitly set, each row is colored 🟢/🔴 by pass/fail against *that category's* vitest threshold (if defined), rather than a single project-wide bucket. If no threshold exists for a given category, it still falls back to 🔵, matching the documented "no thresholds defined" behavior. Explicit `threshold-icons` continues to take precedence when provided, unchanged from current behavior — no change for anyone already using that option.

## Changes
- `src/report/generateSummaryTableHtml.ts`: added a `getStatus()` selector — explicit `thresholdIcons` wins, else per-category vitest `threshold` pass/fail, else blue.
- `src/inputs/options.ts`: `thresholdIcons` is now `undefined` (rather than the all-blue default map) when the user hasn't set `threshold-icons`, so the report layer can distinguish "not configured" from "configured to always be blue."
- `src/report/generateSummaryTableHtml.test.ts`: updated the test that asserted blue-by-default to instead reflect explicit `defaultThresholdIcons` still winning, and added coverage for the new green/red-by-vitest-threshold default.

## Test plan
- [x] `npm run test` — all 152 tests pass
- [x] `npm run lint` on changed files — clean
- [x] Did not touch `dist/`, per CONTRIBUTING.md