### PR TITLE
ci: switch release app token from app-id to client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         id: get_workflow_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_CERT }}
       - name: Semantic Release
         run: npx semantic-release


### PR DESCRIPTION
The `actions/create-github-app-token` action supports `client-id` as a replacement for the deprecated `app-id` input. This PR switches the release workflow to use `client-id` sourced from the `RELEASE_APP_CLIENT_ID` actions variable (not a secret, since client IDs are not sensitive).